### PR TITLE
`return err` 

### DIFF
--- a/nrfiber.go
+++ b/nrfiber.go
@@ -52,7 +52,8 @@ func Middleware(app *newrelic.Application, configs ...*config) fiber.Handler {
 		}
 
 		txn.SetWebResponse(nil).WriteHeader(statusCode)
-		return nil
+
+		return err
 	}
 }
 


### PR DESCRIPTION
so that the error returned from the call chain can continue to propagate up the call chain